### PR TITLE
Ana/typed mapped column

### DIFF
--- a/lib/sqlalchemy/orm/_orm_constructors.py
+++ b/lib/sqlalchemy/orm/_orm_constructors.py
@@ -95,6 +95,139 @@ def contains_alias(alias: Union[Alias, Subquery]) -> AliasOption:
     return AliasOption(alias)
 
 
+# nullable=True -> MappedColumn[Optional[_T]]
+@overload
+def mapped_column(
+    __name_pos: Optional[
+        Union[str, _TypeEngineArgument[_T], SchemaEventTarget]
+    ] = None,
+    __type_pos: Optional[
+        Union[_TypeEngineArgument[_T], SchemaEventTarget]
+    ] = None,
+    *args: SchemaEventTarget,
+    init: Union[_NoArg, bool] = _NoArg.NO_ARG,
+    repr: Union[_NoArg, bool] = _NoArg.NO_ARG,  # noqa: A002
+    default: Optional[Union[_NoArg, _T, Callable[..., _T]]] = _NoArg.NO_ARG,
+    default_factory: Union[_NoArg, Callable[[], _T]] = _NoArg.NO_ARG,
+    compare: Union[_NoArg, bool] = _NoArg.NO_ARG,
+    kw_only: Union[_NoArg, bool] = _NoArg.NO_ARG,
+    nullable: Literal[True],
+    primary_key: Optional[bool] = False,
+    deferred: Union[_NoArg, bool] = _NoArg.NO_ARG,
+    deferred_group: Optional[str] = None,
+    deferred_raiseload: Optional[bool] = None,
+    use_existing_column: bool = False,
+    name: Optional[str] = None,
+    type_: Optional[_TypeEngineArgument[Any]] = None,
+    autoincrement: _AutoIncrementType = "auto",
+    doc: Optional[str] = None,
+    key: Optional[str] = None,
+    index: Optional[bool] = None,
+    unique: Optional[bool] = None,
+    info: Optional[_InfoType] = None,
+    onupdate: Optional[Any] = None,
+    insert_default: Optional[Any] = _NoArg.NO_ARG,
+    server_default: Optional[_ServerDefaultArgument] = None,
+    server_onupdate: Optional[FetchedValue] = None,
+    active_history: bool = False,
+    quote: Optional[bool] = None,
+    system: bool = False,
+    comment: Optional[str] = None,
+    sort_order: Union[_NoArg, int] = _NoArg.NO_ARG,
+    **kw: Any,
+) -> MappedColumn[Optional[_T]]: ...
+
+
+# nullable=False -> MappedColumn[_T]
+@overload
+def mapped_column(
+    __name_pos: Optional[
+        Union[str, _TypeEngineArgument[_T], SchemaEventTarget]
+    ] = None,
+    __type_pos: Optional[
+        Union[_TypeEngineArgument[_T], SchemaEventTarget]
+    ] = None,
+    *args: SchemaEventTarget,
+    init: Union[_NoArg, bool] = _NoArg.NO_ARG,
+    repr: Union[_NoArg, bool] = _NoArg.NO_ARG,  # noqa: A002
+    default: Union[_NoArg, _T, Callable[..., _T]] = _NoArg.NO_ARG,
+    default_factory: Union[_NoArg, Callable[[], _T]] = _NoArg.NO_ARG,
+    compare: Union[_NoArg, bool] = _NoArg.NO_ARG,
+    kw_only: Union[_NoArg, bool] = _NoArg.NO_ARG,
+    nullable: Literal[False],
+    primary_key: Optional[bool] = False,
+    deferred: Union[_NoArg, bool] = _NoArg.NO_ARG,
+    deferred_group: Optional[str] = None,
+    deferred_raiseload: Optional[bool] = None,
+    use_existing_column: bool = False,
+    name: Optional[str] = None,
+    type_: Optional[_TypeEngineArgument[Any]] = None,
+    autoincrement: _AutoIncrementType = "auto",
+    doc: Optional[str] = None,
+    key: Optional[str] = None,
+    index: Optional[bool] = None,
+    unique: Optional[bool] = None,
+    info: Optional[_InfoType] = None,
+    onupdate: Optional[Any] = None,
+    insert_default: Optional[Any] = _NoArg.NO_ARG,
+    server_default: Optional[_ServerDefaultArgument] = None,
+    server_onupdate: Optional[FetchedValue] = None,
+    active_history: bool = False,
+    quote: Optional[bool] = None,
+    system: bool = False,
+    comment: Optional[str] = None,
+    sort_order: Union[_NoArg, int] = _NoArg.NO_ARG,
+    **kw: Any,
+) -> MappedColumn[_T]: ...
+
+
+# nullable unset or None -> MappedColumn[_T]
+# TODO this would be only correct if the default unset nullable was False,
+#  which implies a larger change.
+@overload
+def mapped_column(
+    __name_pos: Optional[
+        Union[str, _TypeEngineArgument[_T], SchemaEventTarget]
+    ] = None,
+    __type_pos: Optional[
+        Union[_TypeEngineArgument[_T], SchemaEventTarget]
+    ] = None,
+    *args: SchemaEventTarget,
+    init: Union[_NoArg, bool] = _NoArg.NO_ARG,
+    repr: Union[_NoArg, bool] = _NoArg.NO_ARG,  # noqa: A002
+    default: Union[_NoArg, _T, Callable[..., _T]] = _NoArg.NO_ARG,
+    default_factory: Union[_NoArg, Callable[[], _T]] = _NoArg.NO_ARG,
+    compare: Union[_NoArg, bool] = _NoArg.NO_ARG,
+    kw_only: Union[_NoArg, bool] = _NoArg.NO_ARG,
+    nullable: Optional[
+        Literal[SchemaConst.NULL_UNSPECIFIED]
+    ] = SchemaConst.NULL_UNSPECIFIED,
+    primary_key: Optional[bool] = False,
+    deferred: Union[_NoArg, bool] = _NoArg.NO_ARG,
+    deferred_group: Optional[str] = None,
+    deferred_raiseload: Optional[bool] = None,
+    use_existing_column: bool = False,
+    name: Optional[str] = None,
+    type_: Optional[_TypeEngineArgument[Any]] = None,
+    autoincrement: _AutoIncrementType = "auto",
+    doc: Optional[str] = None,
+    key: Optional[str] = None,
+    index: Optional[bool] = None,
+    unique: Optional[bool] = None,
+    info: Optional[_InfoType] = None,
+    onupdate: Optional[Any] = None,
+    insert_default: Optional[Any] = _NoArg.NO_ARG,
+    server_default: Optional[_ServerDefaultArgument] = None,
+    server_onupdate: Optional[FetchedValue] = None,
+    active_history: bool = False,
+    quote: Optional[bool] = None,
+    system: bool = False,
+    comment: Optional[str] = None,
+    sort_order: Union[_NoArg, int] = _NoArg.NO_ARG,
+    **kw: Any,
+) -> MappedColumn[_T]: ...
+
+
 def mapped_column(
     __name_pos: Optional[
         Union[str, _TypeEngineArgument[Any], SchemaEventTarget]

--- a/lib/sqlalchemy/sql/type_api.py
+++ b/lib/sqlalchemy/sql/type_api.py
@@ -116,7 +116,7 @@ class _ComparatorFactory(Protocol[_T]):
     ) -> TypeEngine.Comparator[_T]: ...
 
 
-class TypeEngine(Visitable, Generic[_T]):
+class TypeEngine(Visitable, Generic[_T_co]):
     """The ultimate base class for all SQL datatypes.
 
     Common subclasses of :class:`.TypeEngine` include
@@ -359,7 +359,7 @@ class TypeEngine(Visitable, Generic[_T]):
 
     def literal_processor(
         self, dialect: Dialect
-    ) -> Optional[_LiteralProcessorType[_T]]:
+    ) -> Optional[_LiteralProcessorType[_T_co]]:
         """Return a conversion function for processing literal values that are
         to be rendered directly without using binds.
 
@@ -396,7 +396,7 @@ class TypeEngine(Visitable, Generic[_T]):
 
     def bind_processor(
         self, dialect: Dialect
-    ) -> Optional[_BindProcessorType[_T]]:
+    ) -> Optional[_BindProcessorType[_T_co]]:
         """Return a conversion function for processing bind values.
 
         Returns a callable which will receive a bind parameter value
@@ -432,7 +432,7 @@ class TypeEngine(Visitable, Generic[_T]):
 
     def result_processor(
         self, dialect: Dialect, coltype: object
-    ) -> Optional[_ResultProcessorType[_T]]:
+    ) -> Optional[_ResultProcessorType[_T_co]]:
         """Return a conversion function for processing result row values.
 
         Returns a callable which will receive a result row column
@@ -468,8 +468,8 @@ class TypeEngine(Visitable, Generic[_T]):
         return None
 
     def column_expression(
-        self, colexpr: ColumnElement[_T]
-    ) -> Optional[ColumnElement[_T]]:
+        self, colexpr: ColumnElement[_T_co]
+    ) -> Optional[ColumnElement[_T_co]]:
         """Given a SELECT column expression, return a wrapping SQL expression.
 
         This is typically a SQL function that wraps a column expression
@@ -527,8 +527,8 @@ class TypeEngine(Visitable, Generic[_T]):
         )
 
     def bind_expression(
-        self, bindvalue: BindParameter[_T]
-    ) -> Optional[ColumnElement[_T]]:
+        self, bindvalue: BindParameter[_T_co]
+    ) -> Optional[ColumnElement[_T_co]]:
         """Given a bind value (i.e. a :class:`.BindParameter` instance),
         return a SQL expression in its place.
 
@@ -576,7 +576,7 @@ class TypeEngine(Visitable, Generic[_T]):
 
     def _sentinel_value_resolver(
         self, dialect: Dialect
-    ) -> Optional[_SentinelProcessorType[_T]]:
+    ) -> Optional[_SentinelProcessorType[_T_co]]:
         """Return an optional callable that will match parameter values
         (post-bind processing) to result values
         (pre-result-processing), for use in the "sentinel" feature.
@@ -768,7 +768,7 @@ class TypeEngine(Visitable, Generic[_T]):
         return self
 
     @util.ro_memoized_property
-    def _type_affinity(self) -> Optional[Type[TypeEngine[_T]]]:
+    def _type_affinity(self) -> Optional[Type[TypeEngine[_T_co]]]:
         """Return a rudimental 'affinity' value expressing the general class
         of type."""
 
@@ -784,7 +784,7 @@ class TypeEngine(Visitable, Generic[_T]):
     @util.ro_memoized_property
     def _generic_type_affinity(
         self,
-    ) -> Type[TypeEngine[_T]]:
+    ) -> Type[TypeEngine[_T_co]]:
         best_camelcase = None
         best_uppercase = None
 
@@ -811,10 +811,10 @@ class TypeEngine(Visitable, Generic[_T]):
         return (
             best_camelcase
             or best_uppercase
-            or cast("Type[TypeEngine[_T]]", NULLTYPE.__class__)
+            or cast("Type[TypeEngine[_T_co]]", NULLTYPE.__class__)
         )
 
-    def as_generic(self, allow_nulltype: bool = False) -> TypeEngine[_T]:
+    def as_generic(self, allow_nulltype: bool = False) -> TypeEngine[_T_co]:
         """
         Return an instance of the generic type corresponding to this type
         using heuristic rule. The method may be overridden if this
@@ -854,7 +854,7 @@ class TypeEngine(Visitable, Generic[_T]):
 
         return util.constructor_copy(self, self._generic_type_affinity)
 
-    def dialect_impl(self, dialect: Dialect) -> TypeEngine[_T]:
+    def dialect_impl(self, dialect: Dialect) -> TypeEngine[_T_co]:
         """Return a dialect-specific implementation for this
         :class:`.TypeEngine`.
 
@@ -867,7 +867,7 @@ class TypeEngine(Visitable, Generic[_T]):
             return tm["impl"]
         return self._dialect_info(dialect)["impl"]
 
-    def _unwrapped_dialect_impl(self, dialect: Dialect) -> TypeEngine[_T]:
+    def _unwrapped_dialect_impl(self, dialect: Dialect) -> TypeEngine[_T_co]:
         """Return the 'unwrapped' dialect impl for this type.
 
         For a type that applies wrapping logic (e.g. TypeDecorator), give
@@ -883,7 +883,7 @@ class TypeEngine(Visitable, Generic[_T]):
 
     def _cached_literal_processor(
         self, dialect: Dialect
-    ) -> Optional[_LiteralProcessorType[_T]]:
+    ) -> Optional[_LiteralProcessorType[_T_co]]:
         """Return a dialect-specific literal processor for this type."""
 
         try:
@@ -899,7 +899,7 @@ class TypeEngine(Visitable, Generic[_T]):
 
     def _cached_bind_processor(
         self, dialect: Dialect
-    ) -> Optional[_BindProcessorType[_T]]:
+    ) -> Optional[_BindProcessorType[_T_co]]:
         """Return a dialect-specific bind processor for this type."""
 
         try:
@@ -915,7 +915,7 @@ class TypeEngine(Visitable, Generic[_T]):
 
     def _cached_result_processor(
         self, dialect: Dialect, coltype: Any
-    ) -> Optional[_ResultProcessorType[_T]]:
+    ) -> Optional[_ResultProcessorType[_T_co]]:
         """Return a dialect-specific result processor for this type."""
 
         try:
@@ -935,7 +935,7 @@ class TypeEngine(Visitable, Generic[_T]):
 
     def _cached_sentinel_value_processor(
         self, dialect: Dialect
-    ) -> Optional[_SentinelProcessorType[_T]]:
+    ) -> Optional[_SentinelProcessorType[_T_co]]:
         try:
             return dialect._type_memos[self]["sentinel"]
         except KeyError:
@@ -946,7 +946,7 @@ class TypeEngine(Visitable, Generic[_T]):
         return bp
 
     def _cached_custom_processor(
-        self, dialect: Dialect, key: str, fn: Callable[[TypeEngine[_T]], _O]
+        self, dialect: Dialect, key: str, fn: Callable[[TypeEngine[_T_co]], _O]
     ) -> _O:
         """return a dialect-specific processing object for
         custom purposes.

--- a/test/typing/plain_files/orm/issue_9340.py
+++ b/test/typing/plain_files/orm/issue_9340.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from typing import Sequence
 from typing import TYPE_CHECKING
 
@@ -28,7 +29,7 @@ class UserComment(Message):
     __mapper_args__ = {
         "polymorphic_identity": "user_comment",
     }
-    username: Mapped[str] = mapped_column(nullable=True)
+    username: Mapped[Optional[str]] = mapped_column(nullable=True)
 
 
 engine = create_engine("postgresql+psycopg2://scott:tiger@localhost/")

--- a/test/typing/plain_files/orm/mapped_column.py
+++ b/test/typing/plain_files/orm/mapped_column.py
@@ -1,3 +1,4 @@
+import typing
 from typing import Optional
 
 from sqlalchemy import ForeignKey
@@ -44,7 +45,7 @@ class X(Base):
     b: Mapped[Optional[str]] = mapped_column()
 
     # this can't be detected because we don't know the type
-    c: Mapped[str] = mapped_column(nullable=True)
+    c: Mapped[Optional[str]] = mapped_column(nullable=True)
     d: Mapped[str] = mapped_column(nullable=False)
 
     e: Mapped[Optional[str]] = mapped_column(ForeignKey(c), nullable=True)
@@ -58,8 +59,6 @@ class X(Base):
     # this probably is wrong.  however at the moment it seems better to
     # decouple the right hand arguments from declaring things about the
     # left side since it mostly doesn't work in any case.
-    i: Mapped[str] = mapped_column(String, nullable=True)
-
     j: Mapped[str] = mapped_column(String, nullable=False)
 
     k: Mapped[Optional[str]] = mapped_column(String, nullable=True)
@@ -69,7 +68,6 @@ class X(Base):
     a_name: Mapped[str] = mapped_column("a_name")
     b_name: Mapped[Optional[str]] = mapped_column("b_name")
 
-    c_name: Mapped[str] = mapped_column("c_name", nullable=True)
     d_name: Mapped[str] = mapped_column("d_name", nullable=False)
 
     e_name: Mapped[Optional[str]] = mapped_column("e_name", nullable=True)
@@ -78,8 +76,6 @@ class X(Base):
 
     g_name: Mapped[str] = mapped_column("g_name", String)
     h_name: Mapped[Optional[str]] = mapped_column("h_name", String)
-
-    i_name: Mapped[str] = mapped_column("i_name", String, nullable=True)
 
     j_name: Mapped[str] = mapped_column("j_name", String, nullable=False)
 
@@ -94,3 +90,80 @@ class X(Base):
     )
 
     __table_args__ = (UniqueConstraint(a, b, name="uq1"), Index("ix1", c, d))
+
+
+if typing.TYPE_CHECKING:
+    # EXPECTED_RE_TYPE: sqlalchemy.orm.properties.MappedColumn\[builtins.int\]
+    reveal_type(mapped_column(Integer))
+
+    # EXPECTED_RE_TYPE: sqlalchemy.orm.properties.MappedColumn\[Union\[builtins.int, None\]\]
+    reveal_type(mapped_column(Integer, nullable=True))
+
+    # EXPECTED_RE_TYPE: sqlalchemy.orm.properties.MappedColumn\[builtins.int\]
+    reveal_type(mapped_column(Integer, default=7))
+
+    # EXPECTED_MYPY_RE: Argument 1 to "mapped_column" has incompatible type.*
+    a_err: Mapped[str] = mapped_column(Integer)
+
+    # EXPECTED_MYPY_RE: Argument 2 to "mapped_column" has incompatible type.*
+    a_err_name: Mapped[str] = mapped_column("a", Integer)
+
+    # EXPECTED_MYPY_RE: Argument "default" to "mapped_column" has incompatible type "None".*
+    b_err: Mapped[int] = mapped_column(Integer, default=None)
+
+    # EXPECTED_MYPY_RE: Argument "default" to "mapped_column" has incompatible type "None".*
+    b_err_name: Mapped[int] = mapped_column("b", Integer, default=None)
+
+    # EXPECTED_MYPY_RE: Argument "default" to "mapped_column" has incompatible type "None".*
+    c_err: Mapped[int] = mapped_column(default=None)
+
+    # EXPECTED_MYPY_RE: Argument "default" to "mapped_column" has incompatible type "None".*
+    c_err_name: Mapped[int] = mapped_column("c", default=None)
+
+    # EXPECTED_MYPY_RE: Incompatible types in assignment.*
+    d_err: Mapped[int] = mapped_column(Integer, nullable=True)
+
+    # EXPECTED_MYPY_RE: Incompatible types in assignment.*
+    d_err_name: Mapped[int] = mapped_column("d", Integer, nullable=True)
+
+    # EXPECTED_MYPY_RE: Incompatible types in assignment.*
+    e_err: Mapped[int] = mapped_column(nullable=True)
+
+    # EXPECTED_MYPY_RE: Incompatible types in assignment.*
+    e_err_name: Mapped[int] = mapped_column("e", nullable=True)
+
+    # EXPECTED_MYPY_RE: Argument "default" to "mapped_column" has incompatible type.*
+    f_err: Mapped[int] = mapped_column(default="a")
+
+    # EXPECTED_MYPY_RE: Argument "default" to "mapped_column" has incompatible type.*
+    f_err_name: Mapped[int] = mapped_column("f", default="a")
+
+    # All of these are fine
+    x1: Mapped[str] = mapped_column(String, default="a", nullable=False)
+    x2: Mapped[str] = mapped_column(String, default="a")
+    x3: Mapped[str] = mapped_column(default="a", nullable=False)
+    x4: Mapped[str] = mapped_column(String, nullable=False)
+    x5: Mapped[str] = mapped_column(String)
+    x6: Mapped[str] = mapped_column(default="a")
+    x7: Mapped[str] = mapped_column(nullable=False)
+    x8: Mapped[str] = mapped_column()
+
+    y1: Mapped[Optional[int]] = mapped_column(
+        Integer, default=None, nullable=True
+    )
+    y2: Mapped[Optional[int]] = mapped_column(Integer, default=None)
+    y3: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    y4: Mapped[Optional[int]] = mapped_column(default=None, nullable=True)
+    y5: Mapped[Optional[int]] = mapped_column(default=None)
+    y6: Mapped[Optional[int]] = mapped_column(Integer)
+    y7: Mapped[Optional[int]] = mapped_column(nullable=True)
+    y8: Mapped[Optional[int]] = mapped_column()
+
+    z1: Mapped[int] = mapped_column(Integer, default=7, nullable=False)
+    z2: Mapped[int] = mapped_column(Integer, default=7)
+    z3: Mapped[int] = mapped_column(default=7, nullable=False)
+    z4: Mapped[int] = mapped_column(Integer, nullable=False)
+    z5: Mapped[int] = mapped_column(Integer)
+    z6: Mapped[int] = mapped_column(default=7)
+    z7: Mapped[int] = mapped_column(nullable=False)
+    z8: Mapped[int] = mapped_column()

--- a/test/typing/plain_files/orm/relationship.py
+++ b/test/typing/plain_files/orm/relationship.py
@@ -35,11 +35,6 @@ class User(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column()
 
-    # this currently doesnt generate an error.  not sure how to get the
-    # overloads to hit this one, nor am i sure i really want to do that
-    # anyway
-    name_this_works_atm: Mapped[str] = mapped_column(nullable=True)
-
     extra: Mapped[Optional[str]] = mapped_column()
     extra_name: Mapped[Optional[str]] = mapped_column("extra_name")
 


### PR DESCRIPTION
**NOTE: Additional changes are required before this can be merged.**
Discussion: https://github.com/sqlalchemy/sqlalchemy/discussions/11093

### Description

**Summary**
These are some efforts to get better typing of `mapped_column`. I believe the return type of `mapped_column` cannot be expressed correctly as it is now. It would be required to change the default value of `nullable` to get types correct.

**Context**
Right now, `mapped_column` returns `MappedColumn[Any]` so there is no guarantee that the type annotation matches the SQLA type engine passed to mapped_column (if any).
https://github.com/sqlalchemy/sqlalchemy/discussions/11093

When I first started the discussion I was hopeful that this could be fully solved with overloads. But now I think it is just not possible to type `mapped_column` correctly as long as the default value for `nullable` is `True`. Because then
there is no way to type something like `mapped_column(Integer)` correctly. `mapped_column(Integer)` can either be of type `MappedColumn[int]` or `MappedColumn[Optional[int]]`, and the default should be the more specific type of those two, namely `MappedColumn[int]` since both of the following assignments should be valid:

```
x: Mapped[int]  = mapped_column(Integer)
y: Mapped[Optional[int]]  = mapped_column(Integer)
```

**In this PR:**

1. Modified type annotations in `mapped_column` to
* Return `MappedColumn` type matching the type engine, the `nullable`  and the `default` parameters.

2. Made `TypeEngine` covariant. This was necessary for assignments such as

```
x: Mapped[Optional[int]] = mapped_column(Integer)
```

to be valid for the typechecker.

3. Added typing tests. This section gives a good overview of what this change is about.
